### PR TITLE
CI: Run central go test script

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2017-2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 set -e
 
-test_packages=$(go list ./... | grep -v vendor)
-echo "Run go test and generate coverage:"
-for pkg in $test_packages; do
-	if [ "$pkg" = "github.com/kata-containers/ksm-throttler" ]; then
-		sudo env GOPATH=$GOPATH GOROOT=$GOROOT PATH=$PATH go test -cover -coverprofile=profile.cov $pkg
-	else
-		sudo env GOPATH=$GOPATH GOROOT=$GOROOT PATH=$PATH go test -cover $pkg
-	fi
-done
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_go_test

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -23,3 +23,9 @@ run_static_checks()
 	clone_tests_repo
 	bash "$tests_repo_dir/.ci/static-checks.sh"
 }
+
+run_go_test()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/go-test.sh"
+}


### PR DESCRIPTION
Run `go test` via the tests repositories script. This will allow all
the unit test logic to be confined to a single location and ensure
cross-repository consistency.

Fixes #13.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>