### PR TITLE
logging: Switch to nanosecond timestamps

### DIFF
--- a/throttler.go
+++ b/throttler.go
@@ -109,6 +109,8 @@ func SetLoggingLevel(l string) error {
 
 	logrus.SetLevel(level)
 
+	throttlerLog.Logger.Formatter = &logrus.TextFormatter{TimestampFormat: time.RFC3339Nano}
+
 	throttlerLog.WithField("version", version).Info()
 
 	return nil


### PR DESCRIPTION
For consistency with other system elements, use nanosecond
log timestamps.

Fixes #21.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>