### PR TITLE
signals: Add standard signal handling

### DIFF
--- a/ksm.go
+++ b/ksm.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/signals/signals.go
+++ b/pkg/signals/signals.go
@@ -1,0 +1,120 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package signals
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+var signalLog = logrus.WithField("default-signal-logger", true)
+
+// CrashOnError causes a coredump to be produced when an internal error occurs
+// or a fatal signal is received.
+var CrashOnError = false
+
+// List of handled signals.
+//
+// The value is true if receiving the signal should be fatal.
+var handledSignalsMap = map[syscall.Signal]bool{
+	syscall.SIGABRT:   true,
+	syscall.SIGBUS:    true,
+	syscall.SIGILL:    true,
+	syscall.SIGQUIT:   true,
+	syscall.SIGSEGV:   true,
+	syscall.SIGSTKFLT: true,
+	syscall.SIGSYS:    true,
+	syscall.SIGTRAP:   true,
+	syscall.SIGUSR1:   false,
+}
+
+// SetLogger sets the custom logger to be used by this package. If not called,
+// the package will create its own logger.
+func SetLogger(logger *logrus.Entry) {
+	signalLog = logger
+}
+
+// HandlePanic writes a message to the logger and then calls Die().
+func HandlePanic() {
+	r := recover()
+
+	if r != nil {
+		msg := fmt.Sprintf("%s", r)
+		signalLog.WithField("panic", msg).Error("fatal error")
+
+		Die()
+	}
+}
+
+// Backtrace writes a multi-line backtrace to the logger.
+func Backtrace() {
+	profiles := pprof.Profiles()
+
+	buf := &bytes.Buffer{}
+
+	for _, p := range profiles {
+		// The magic number requests a full stacktrace. See
+		// https://golang.org/pkg/runtime/pprof/#Profile.WriteTo.
+		pprof.Lookup(p.Name()).WriteTo(buf, 2)
+	}
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		signalLog.Error(line)
+	}
+}
+
+// FatalSignal returns true if the specified signal should cause the program
+// to abort.
+func FatalSignal(sig syscall.Signal) bool {
+	s, exists := handledSignalsMap[sig]
+	if !exists {
+		return false
+	}
+
+	return s
+}
+
+// NonFatalSignal returns true if the specified signal should simply cause the
+// program to Backtrace() but continue running.
+func NonFatalSignal(sig syscall.Signal) bool {
+	s, exists := handledSignalsMap[sig]
+	if !exists {
+		return false
+	}
+
+	return !s
+}
+
+// HandledSignals returns a list of signals the package can deal with.
+func HandledSignals() []syscall.Signal {
+	var signals []syscall.Signal
+
+	for sig := range handledSignalsMap {
+		signals = append(signals, sig)
+	}
+
+	return signals
+}
+
+// Die causes a backtrace to be produced. If CrashOnError is set a coredump
+// will be produced, else the program will exit.
+func Die() {
+	Backtrace()
+
+	if CrashOnError {
+		signal.Reset(syscall.SIGABRT)
+		syscall.Kill(0, syscall.SIGABRT)
+	}
+
+	os.Exit(1)
+}

--- a/pkg/signals/signals_test.go
+++ b/pkg/signals/signals_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package signals
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+	goruntime "runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignalFatalSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	for sig, fatal := range handledSignalsMap {
+		result := NonFatalSignal(sig)
+		if fatal {
+			assert.False(result)
+		} else {
+			assert.True(result)
+		}
+	}
+}
+
+func TestSignalHandledSignalsMap(t *testing.T) {
+	assert := assert.New(t)
+
+	for sig, fatal := range handledSignalsMap {
+		result := FatalSignal(sig)
+		if fatal {
+			assert.True(result)
+		} else {
+			assert.False(result)
+		}
+	}
+}
+
+func TestSignalHandledSignals(t *testing.T) {
+	assert := assert.New(t)
+
+	var expected []syscall.Signal
+
+	for sig := range handledSignalsMap {
+		expected = append(expected, sig)
+	}
+
+	got := HandledSignals()
+
+	sort.Slice(expected, func(i, j int) bool {
+		return int(expected[i]) < int(expected[j])
+	})
+
+	sort.Slice(got, func(i, j int) bool {
+		return int(got[i]) < int(got[j])
+	})
+
+	assert.True(reflect.DeepEqual(expected, got))
+}
+
+func TestSignalNonFatalSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	for sig, fatal := range handledSignalsMap {
+		result := NonFatalSignal(sig)
+		if fatal {
+			assert.False(result)
+		} else {
+			assert.True(result)
+		}
+	}
+}
+
+func TestSignalFatalSignalInvalidSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	sig := syscall.SIGXCPU
+
+	result := FatalSignal(sig)
+	assert.False(result)
+}
+
+func TestSignalNonFatalSignalInvalidSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	sig := syscall.SIGXCPU
+
+	result := NonFatalSignal(sig)
+	assert.False(result)
+}
+
+func TestSignalBacktrace(t *testing.T) {
+	assert := assert.New(t)
+
+	savedLog := signalLog
+	defer func() {
+		signalLog = savedLog
+	}()
+
+	signalLog = logrus.WithFields(logrus.Fields{
+		"name":        "name",
+		"pid":         os.Getpid(),
+		"source":      "throttler",
+		"test-logger": true})
+
+	// create buffer to save logger output
+	buf := &bytes.Buffer{}
+
+	savedOut := signalLog.Logger.Out
+	defer func() {
+		signalLog.Logger.Out = savedOut
+	}()
+
+	// capture output to buffer
+	signalLog.Logger.Out = buf
+
+	// determine name of *this* function
+	pc := make([]uintptr, 1)
+	goruntime.Callers(1, pc)
+	fn := goruntime.FuncForPC(pc[0])
+	name := fn.Name()
+
+	Backtrace()
+
+	b := buf.String()
+
+	// very basic tests to check if a backtrace was produced
+	assert.True(strings.Contains(b, "contention:"))
+	assert.True(strings.Contains(b, `level=error`))
+	assert.True(strings.Contains(b, name))
+}

--- a/throttler.go
+++ b/throttler.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/trigger/virtcontainers/vc.go
+++ b/trigger/virtcontainers/vc.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2017-2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
Add the standard project signal handling. However, since it needs to be
applied to two different binaries, encapsulate it in a new package.

Fixes #32.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>