### PR TITLE
ci: travis: update golang to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
 language: go
 sudo: required
 go:
-- 1.8
-- 1.9
+- 1.11.x
 - tip
 go_import_path: github.com/kata-containers/ksm-throttler
 

--- a/trigger/virtcontainers/vc.go
+++ b/trigger/virtcontainers/vc.go
@@ -115,13 +115,11 @@ func waitForDirectory(dir string) error {
 		return err
 	}
 
-	select {
-	case syncErr := <-syncCh:
-		if syncErr == nil {
-			logger.Debug("directory created")
-		}
-		return err
+	syncErr := <-syncCh
+	if syncErr == nil {
+		logger.Debug("directory created")
 	}
+	return err
 }
 
 func monitorPods(vcRunRoot, throttler string) error {


### PR DESCRIPTION
We move to golang 1.11 on Jenkins but not travis.

This makes fail when ci tries to build linters.

Fixes: #82