### PR TITLE
travis: Specify go version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@
 #
 
 ---
-language: go
 sudo: required
 
 os:
 - linux
 - linux-ppc64le
 
+language: go
+go:
+  - 1.13.9
+
 go_import_path: github.com/kata-containers/ksm-throttler
 
 before_script:
   - ".ci/setup.sh"
-  # go version should pass with:
-  # https://github.com/kata-containers/runtime/blob/master/versions.yaml
-  - ".ci/install_go.sh"
   - ".ci/static-checks.sh"
 
 install:


### PR DESCRIPTION
Do not use `.ci/install_go.sh` as it has been causing issues.

Fixes. #139.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>