### PR TITLE
actions: Add new issues to project

### DIFF
--- a/.github/workflows/add-issues-to-project.yaml
+++ b/.github/workflows/add-issues-to-project.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: Add newly created issues to the backlog project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-new-issues-to-backlog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install hub
+        run: |
+          HUB_ARCH="amd64"
+          HUB_VER=$(curl -sL "https://api.github.com/repos/github/hub/releases/latest" |\
+            jq -r .tag_name | sed 's/^v//')
+          curl -sL \
+            "https://github.com/github/hub/releases/download/v${HUB_VER}/hub-linux-${HUB_ARCH}-${HUB_VER}.tgz" |\
+          tar xz --strip-components=2 --wildcards '*/bin/hub' && \
+          sudo install hub /usr/local/bin
+
+      - name: Install hub extension script
+        run: |
+          # Clone into a temporary directory to avoid overwriting
+          # any existing github directory.
+          pushd $(mktemp -d) &>/dev/null
+          git clone --single-branch --depth 1 "https://github.com/kata-containers/.github" && cd .github/scripts
+          sudo install hub-util.sh /usr/local/bin
+          popd &>/dev/null
+
+      - name: Checkout code to allow hub to communicate with the project
+        uses: actions/checkout@v2
+
+      - name: Add issue to issue backlog
+        env:
+          GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
+        run: |
+            issue=${{ github.event.issue.number }}
+            project_name="Issue backlog"
+            project_type="org"
+            project_column="To do"
+
+            hub-util.sh \
+                add-issue \
+                "$issue" \
+                "$project_name" \
+                "$project_type" \
+                "$project_column"


### PR DESCRIPTION
Add configuration to trigger a new GitHub action for the repository that
will add all newly created issues to the organisation-level issue
backlog project.

Fixes: #157.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>